### PR TITLE
Duplicate Code and Whitespace Handing

### DIFF
--- a/gec/correcter.py
+++ b/gec/correcter.py
@@ -1,3 +1,4 @@
+import re
 from ua_gec import AnnotatedText
 from transformers import pipeline, Pipeline
 from .transformations import Transformations
@@ -23,7 +24,7 @@ class Correcter:
             that are computed, e.g. $PREPEND__PUNCTUATION__START_—_SPACE_
         """
         self.classifier = classifier if classifier else self._load_classifier()
-        self.annotated_text = AnnotatedText(text)
+        self.annotated_text = AnnotatedText(re.sub(' +', ' ', text))
         self.min_score = min_score
         self.min_delete_score = min_delete_score
         self.exclude_tags = exclude_tags


### PR DESCRIPTION
# What does this change resolve?
- Remove duplicate code
- Remove excessive spaces from a string before correcting it. This is needed to avoid handing the `$DELETE` tag for spaces that sometimes can result in the removal of the word itself
- Decrease the `EarlyStoppingCallback` threshold to 1 as this value results in a better model